### PR TITLE
Explicitely say that the team will be created if it's missing

### DIFF
--- a/lib/entitlements/backend/github_team/service.rb
+++ b/lib/entitlements/backend/github_team/service.rb
@@ -111,7 +111,7 @@ module Entitlements
                   metadata: team_metadata
                 )
               rescue TeamNotFound
-                Entitlements.logger.warn "Team #{team_identifier} does not exist in this GitHub.com organization"
+                Entitlements.logger.warn "Team #{team_identifier} does not exist in this GitHub.com organization. If applied, the team will be created."
                 return nil
               end
 

--- a/spec/unit/entitlements/backend/github_team/service_spec.rb
+++ b/spec/unit/entitlements/backend/github_team/service_spec.rb
@@ -84,7 +84,7 @@ describe Entitlements::Backend::GitHubTeam::Service do
 
       expect(logger).to receive(:debug).with("Setting up GitHub API connection to https://github.fake/api/v3/")
       expect(logger).to receive(:debug).with("Loading GitHub team github.fake:kittensinc/team-does-not-exist")
-      expect(logger).to receive(:warn).with("Team team-does-not-exist does not exist in this GitHub.com organization")
+      expect(logger).to receive(:warn).with("Team team-does-not-exist does not exist in this GitHub.com organization. If applied, the team will be created.")
       result = subject.read_team(entitlement_group_doesnt_exist)
       expect(result).to eq(nil)
     end


### PR DESCRIPTION
This plugin creates missing github.com teams, however the missing team warning left ambiguous what would happen if a team was missing.

This PR adds a clarification message in the warning. IMHO the warning is still valuable but benefits from clarity.