### PR TITLE
Support: role maintainer in team membership

### DIFF
--- a/lib/entitlements/backend/github_team/service.rb
+++ b/lib/entitlements/backend/github_team/service.rb
@@ -420,6 +420,7 @@ module Entitlements
         def add_user_to_team(user:, team:, role: "member")
           return false unless org_members.include?(user.downcase)
           unless role == "member" || role == "maintainer"
+            # :nocov:
             raise "add_user_to_team role mismatch: team_id=#{team.team_id} user=#{user} expected role=maintainer/member got=#{role}"
           end
           Entitlements.logger.debug "#{identifier} add_user_to_team(user=#{user}, org=#{org}, team_id=#{team.team_id}, role=#{role})"


### PR DESCRIPTION
This PR introduces support for adding team members with role: `maintainer` (rather than only role:`member` which is the current behaviour).

The current behaviour can lead to teams that have members but have no maintainers associated with them which makes the team difficult to administer. When this happens it will require an org admin to manage the team.

With this PR it's possible to specify metadata: `team_maintainers: a,b,c` which will make users `a`,`b`,`c` obtain the maintainer role (note: we require that all `team_maintainers` are members of the team).

Note: that I was unable to run acceptance tests locally (I couldn't find the instructions), but unit tests pass and I've added unit tests for the different scenarios regarding maintainers.
