### PR TITLE
Publish to rubygems in ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,11 @@ jobs:
           artifacts: "${{ env.GEM_NAME }}-${{ env.GEM_VERSION }}.gem"
           tag: "v${{ env.GEM_VERSION }}"
           generateReleaseNotes: true
+      
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p ~/.gem
+          echo -e "---\n:rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" > ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          gem push ${{ env.GEM_NAME }}-${{ env.GEM_VERSION }}.gem
+          rm ~/.gem/credentials

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entitlements-github-plugin (0.4.0)
+    entitlements-github-plugin (0.4.1)
       contracts (= 0.17.0)
       faraday (~> 2.0)
       faraday-retry (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ To release a new version of this Gem, do the following:
 2. Run `bundle install` to update the `Gemfile.lock` file with the new version
 3. Commit your changes, push them to GitHub, and open a PR
 
-Once your PR is approved and the changes are merged, a new release will be created automatically by the [`release.yml`](.github/workflows/release.yml) workflow. The latest version of the Gem will be published to the GitHub Package Registry.
+Once your PR is approved and the changes are merged, a new release will be created automatically by the [`release.yml`](.github/workflows/release.yml) workflow. The latest version of the Gem will be published to the GitHub Package Registry and RubyGems.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Entitlements
   module Version
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end


### PR DESCRIPTION
This pull request allows the publishing to RubyGems to take place in CI, rather than being done manually by a maintainer. This release process takes place upon a `merge` event or a `push` to `main` when `lib/version.rb` is updated.

> API keys for RubyGems have already been added to this repository