### PR TITLE
Fix syncing team maintainers.

### DIFF
--- a/lib/entitlements/backend/github_team/provider.rb
+++ b/lib/entitlements/backend/github_team/provider.rb
@@ -198,6 +198,23 @@ module Entitlements
               Entitlements.logger.info "CHANGE github_parent_team from #{existing_parent_team} to #{changed_parent_team} for #{existing_group.dn} in #{github.org}"
             end
           end
+
+          existing_maintainers = existing_group.metadata_fetch_if_exists("team_maintainers")
+          changed_maintainers = group.metadata_fetch_if_exists("team_maintainers")
+          if existing_maintainers != changed_maintainers
+            base_diff[:metadata] ||= {}
+            if existing_maintainers.nil? && !changed_maintainers.nil?
+              base_diff[:metadata][:team_maintainers] = "add"
+              Entitlements.logger.info "ADD github_team_maintainers #{changed_maintainers} to #{existing_group.dn} in #{github.org}"
+            elsif !existing_maintainers.nil? && changed_maintainers.nil?
+              base_diff[:metadata][:team_maintainers] = "remove"
+              Entitlements.logger.info "REMOVE (NOOP) github_team_maintainers #{existing_maintainers} from #{existing_group.dn} in #{github.org}"
+            else
+              base_diff[:metadata][:team_maintainers] = "change"
+              Entitlements.logger.info "CHANGE github_team_maintainers from #{existing_maintainers} to #{changed_maintainers} for #{existing_group.dn} in #{github.org}"
+            end
+          end
+
           base_diff
         end
 

--- a/spec/acceptance/github-server/web.rb
+++ b/spec/acceptance/github-server/web.rb
@@ -73,7 +73,7 @@ class FakeGitHubApi < Sinatra::Base
       cursor_flag = cursor.nil?
       members.each do |m|
         next if !cursor_flag && Base64.strict_encode64(m) != cursor
-        edges << { "node" => { "login" => m }, "cursor" => Base64.strict_encode64(m) } if cursor_flag
+        edges << { "node" => { "login" => m }, "role" => "MEMBER", "cursor" => Base64.strict_encode64(m) } if cursor_flag
         cursor_flag = true
         break if edges.size >= first
       end

--- a/spec/acceptance/tests/01_basic_webserver_github_connectivity_spec.rb
+++ b/spec/acceptance/tests/01_basic_webserver_github_connectivity_spec.rb
@@ -51,6 +51,7 @@ describe Entitlements do
                 node {
                   login
                 }
+                role
                 cursor
               }
             },
@@ -78,13 +79,13 @@ describe Entitlements do
                 "databaseId" => 6,
                 "members" => {
                   "edges" => [
-                    { "node" => { "login" => "cheetoh" }, "cursor" => "Y2hlZXRvaA==" },
-                    { "node" => { "login" => "khaomanee" }, "cursor" => "a2hhb21hbmVl" },
-                    { "node" => { "login" => "nebelung" }, "cursor" => "bmViZWx1bmc=" },
-                    { "node" => { "login" => "ojosazules" }, "cursor" => "b2pvc2F6dWxlcw==" }
+                    { "node" => { "login" => "cheetoh" }, "role" => "MEMBER", "cursor" => "Y2hlZXRvaA==" },
+                    { "node" => { "login" => "khaomanee" }, "role" => "MEMBER", "cursor" => "a2hhb21hbmVl" },
+                    { "node" => { "login" => "nebelung" }, "role" => "MEMBER", "cursor" => "bmViZWx1bmc=" },
+                    { "node" => { "login" => "ojosazules" }, "role" => "MEMBER", "cursor" => "b2pvc2F6dWxlcw==" }
                   ]
                 },
-                "parentTeam" => { "slug" => nil }
+                "parentTeam" => { "slug" => nil },
               }
             }
           }

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -46,7 +46,7 @@ end
 def graphql_response(team, slice_start, slice_length, parent_team: nil)
   team_id = rand(1..10000)
   edges = team.member_strings.sort.to_a.slice(slice_start, slice_length).map do |m|
-    { "node" => { "login" => m }, "cursor" => Base64.encode64(m) }
+    { "node" => { "login" => m }, "role" => "MEMBER", "cursor" => Base64.encode64(m) }
   end
   struct = {
     "data" => {


### PR DESCRIPTION
This implements a few fixes for team maintainer management. Firstly team maintainers were not being included in the diff to determine whether a team needs synchronizing. Secondly the current team maintainers were not being fetched from GitHub.com, only the predictive cache.