### PR TITLE
Bump the version to 0.4.2.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entitlements-github-plugin (0.4.1)
+    entitlements-github-plugin (0.4.2)
       contracts (= 0.17.0)
       faraday (~> 2.0)
       faraday-retry (~> 2.0)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Entitlements
   module Version
-    VERSION = "0.4.1"
+    VERSION = "0.4.2"
   end
 end


### PR DESCRIPTION
This bumps the version to include the fixes to the GitHub team maintainer management feature.