### PR TITLE
refactor(graphql): improve queries by returning a simple cursor

### DIFF
--- a/lib/entitlements/service/github.rb
+++ b/lib/entitlements/service/github.rb
@@ -210,8 +210,8 @@ module Entitlements
                     login
                   }
                   role
-                  cursor
                 }
+                pageInfo { endCursor }
               }
             }
           }".gsub(/\n\s+/, "\n")
@@ -222,14 +222,15 @@ module Entitlements
             raise "GraphQL query failure"
           end
 
-          edges = response[:data].fetch("data").fetch("organization").fetch("membersWithRole").fetch("edges")
+          membersWithRole = response[:data].fetch("data").fetch("organization").fetch("membersWithRole")
+          edges = membersWithRole.fetch("edges")
           break unless edges.any?
 
           edges.each do |edge|
             result[edge.fetch("node").fetch("login").downcase] = edge.fetch("role")
           end
 
-          cursor = edges.last.fetch("cursor")
+          cursor = membersWithRole.fetch("pageInfo").fetch("endCursor")
           next if cursor && edges.size == max_graphql_results
           break
         end
@@ -276,8 +277,8 @@ module Entitlements
                   node {
                     login
                   }
-                  cursor
                 }
+                pageInfo { endCursor }
               }
             }
           }".gsub(/\n\s+/, "\n")
@@ -288,14 +289,15 @@ module Entitlements
             raise "GraphQL query failure"
           end
 
-          edges = response[:data].fetch("data").fetch("organization").fetch("pendingMembers").fetch("edges")
+          pendingMembers = response[:data].fetch("data").fetch("organization").fetch("pendingMembers")
+          edges = pendingMembers.fetch("edges")
           break unless edges.any?
 
           edges.each do |edge|
             result.add(edge.fetch("node").fetch("login").downcase)
           end
 
-          cursor = edges.last.fetch("cursor")
+          cursor = pendingMembers.fetch("pageInfo").fetch("endCursor")
           next if cursor && edges.size == max_graphql_results
           break
         end

--- a/spec/unit/fixtures/graphql-output/organization-members-page1.json
+++ b/spec/unit/fixtures/graphql-output/organization-members-page1.json
@@ -7,24 +7,24 @@
             "node": {
               "login": "monalisa"
             },
-            "role": "ADMIN",
-            "cursor": "Y3Vyc29yOnYyOpEB"
+            "role": "ADMIN"
           },
           {
             "node": {
               "login": "ocicat"
             },
-            "role": "MEMBER",
-            "cursor": "Y3Vyc29yOnYyOpEF"
+            "role": "MEMBER"
           },
           {
             "node": {
               "login": "blackmanx"
             },
-            "role": "MEMBER",
-            "cursor": "Y3Vyc29yOnYyOpEG"
+            "role": "MEMBER"
           }
-        ]
+        ],
+        "pageInfo": {
+          "endCursor": "Y3Vyc29yOnYyOpEG"
+        }
       }
     }
   }

--- a/spec/unit/fixtures/graphql-output/organization-members-page2.json
+++ b/spec/unit/fixtures/graphql-output/organization-members-page2.json
@@ -7,24 +7,24 @@
             "node": {
               "login": "toyger"
             },
-            "role": "MEMBER",
-            "cursor": "Y3Vyc29yOnYyOpEH"
+            "role": "MEMBER"
           },
           {
             "node": {
               "login": "highlander"
             },
-            "role": "MEMBER",
-            "cursor": "Y3Vyc29yOnYyOpEI"
+            "role": "MEMBER"
           },
           {
             "node": {
               "login": "RussianBlue"
             },
-            "role": "MEMBER",
-            "cursor": "Y3Vyc29yOnYyOpEJ"
+            "role": "MEMBER"
           }
-        ]
+        ],
+        "pageInfo": {
+          "endCursor": "Y3Vyc29yOnYyOpEJ"
+        }
       }
     }
   }

--- a/spec/unit/fixtures/graphql-output/organization-members-page3.json
+++ b/spec/unit/fixtures/graphql-output/organization-members-page3.json
@@ -7,24 +7,24 @@
             "node": {
               "login": "ragamuffin"
             },
-            "role": "MEMBER",
-            "cursor": "Y3Vyc29yOnYyOpEK"
+            "role": "MEMBER"
           },
           {
             "node": {
               "login": "mainecoon"
             },
-            "role": "MEMBER",
-            "cursor": "Y3Vyc29yOnYyOpEL"
+            "role": "MEMBER"
           },
           {
             "node": {
               "login": "laperm"
             },
-            "role": "MEMBER",
-            "cursor": "Y3Vyc29yOnYyOpEM"
+            "role": "MEMBER"
           }
-        ]
+        ],
+        "pageInfo": {
+          "endCursor": "Y3Vyc29yOnYyOpEM"
+        }
       }
     }
   }

--- a/spec/unit/fixtures/graphql-output/organization-members-page4.json
+++ b/spec/unit/fixtures/graphql-output/organization-members-page4.json
@@ -7,10 +7,12 @@
             "node": {
               "login": "peterbald"
             },
-            "role": "MEMBER",
-            "cursor": "Y3Vyc29yOnYyOpEN"
+            "role": "MEMBER"
           }
-        ]
+        ],
+        "pageInfo": {
+          "endCursor": "Y3Vyc29yOnYyOpEN"
+        }
       }
     }
   }

--- a/spec/unit/fixtures/graphql-output/pending-members-page1.json
+++ b/spec/unit/fixtures/graphql-output/pending-members-page1.json
@@ -6,22 +6,22 @@
           {
             "node": {
               "login": "alice"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEB"
+            }
           },
           {
             "node": {
               "login": "bob"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEF"
+            }
           },
           {
             "node": {
               "login": "charles"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEG"
           }
-        ]
+          }
+        ],
+        "pageInfo": {
+          "endCursor": "Y3Vyc29yOnYyOpEG"
+        }
       }
     }
   }

--- a/spec/unit/fixtures/graphql-output/pending-members-page2.json
+++ b/spec/unit/fixtures/graphql-output/pending-members-page2.json
@@ -6,22 +6,22 @@
           {
             "node": {
               "login": "DAVID"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEH"
+            }
           },
           {
             "node": {
               "login": "edward"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEI"
+            }
           },
           {
             "node": {
               "login": "frank"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEJ"
+            }
           }
-        ]
+        ],
+        "pageInfo": {
+          "endCursor": "Y3Vyc29yOnYyOpEJ"
+        }
       }
     }
   }

--- a/spec/unit/fixtures/graphql-output/pending-members-page3.json
+++ b/spec/unit/fixtures/graphql-output/pending-members-page3.json
@@ -6,22 +6,22 @@
           {
             "node": {
               "login": "george"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEK"
+            }
           },
           {
             "node": {
               "login": "harriet"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEL"
+            }
           },
           {
             "node": {
               "login": "ingrid"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEM"
+            }
           }
-        ]
+        ],
+        "pageInfo": {
+          "endCursor": "Y3Vyc29yOnYyOpEM"
+        }
       }
     }
   }

--- a/spec/unit/fixtures/graphql-output/pending-members-page4.json
+++ b/spec/unit/fixtures/graphql-output/pending-members-page4.json
@@ -6,10 +6,12 @@
           {
             "node": {
               "login": "blackmanx"
-            },
-            "cursor": "Y3Vyc29yOnYyOpEN"
+            }
           }
-        ]
+        ],
+        "pageInfo": {
+          "endCursor": "Y3Vyc29yOnYyOpEN"
+        }
       }
     }
   }


### PR DESCRIPTION
The `membersWithRole` connection has a `pageInfo` containing the `endCursor`. It is equivalent to look at the last edge's cursor but creates a smaller return object.

This update the queries, code and fixtures to reflect the new way to paginate.

Proof the cursor is the same using https://docs.github.com/en/graphql/overview/explorer:
![image](https://github.com/github/entitlements-github-plugin/assets/2452791/fb29f9cd-fe98-4eb6-ab33-864696bed660)
