### PR TITLE
Fix an issue where upper-case letters in desired maintainers always cause a diff to be generated.

### DIFF
--- a/lib/entitlements/backend/github_team/provider.rb
+++ b/lib/entitlements/backend/github_team/provider.rb
@@ -199,8 +199,8 @@ module Entitlements
             end
           end
 
-          existing_maintainers = existing_group.metadata_fetch_if_exists("team_maintainers")
-          changed_maintainers = group.metadata_fetch_if_exists("team_maintainers")
+          existing_maintainers = existing_group.metadata_fetch_if_exists("team_maintainers")&.downcase
+          changed_maintainers = group.metadata_fetch_if_exists("team_maintainers")&.downcase
           if existing_maintainers != changed_maintainers
             base_diff[:metadata] ||= {}
             if existing_maintainers.nil? && !changed_maintainers.nil?

--- a/spec/unit/entitlements/backend/github_team/provider_spec.rb
+++ b/spec/unit/entitlements/backend/github_team/provider_spec.rb
@@ -429,6 +429,28 @@ describe Entitlements::Backend::GitHubTeam::Provider do
         metadata: { team_maintainers: "remove" }
       )
     end
+
+    it "diffs team maintainers no change" do
+      entitlements_group = Entitlements::Models::Group.new(
+        dn: "cn=diff-cats,ou=Github,dc=github,dc=fake",
+        members: Set.new(%w[cuddles fluffy morris WHISKERS].map { |u| "uid=#{u},ou=People,dc=kittens,dc=net" }),
+        metadata: { "team_maintainers" => "cuddles,Fluffy" }
+      )
+
+      github_team = Entitlements::Backend::GitHubTeam::Models::Team.new(
+        team_id: 2222,
+        team_name: "diff-cats",
+        members: Set.new(%w[cuddles fluffy morris WHISKERS].map { |u| "uid=#{u},ou=People,dc=kittens,dc=net" }),
+        ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake",
+        metadata: { "team_maintainers" => "cuddles,fluffy" }
+      )
+
+      result = subject.diff_existing_updated(entitlements_group, github_team)
+      expect(result).to eq(
+        added: Set.new,
+        removed: Set.new,
+      )
+    end
   end
 
   describe "#create_github_team_group" do


### PR DESCRIPTION
When getting the current team maintainers, the logins are correctly normalized to lower-case, however the desired team maintainers are not. This results in spurious diff entries appearing if someone uses upper-case characters in this field.

I think we can avoid these by downcasing these fields before this comparison.