### PR TITLE
Support ignoring 404s when user is not found in GitHub instance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entitlements-github-plugin (0.4.4)
+    entitlements-github-plugin (0.5.0)
       contracts (~> 0.17.0)
       faraday (~> 2.0)
       faraday-retry (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Any plugins defined in `lib/entitlements-and-plugins` will be loaded and used at
     dir: github.com/github/org
     org: github
     token: <%= ENV["GITHUB_ORG_TOKEN"] %>
+    ignore_not_found: false # optional argument to ignore users who are not found in the GitHub instance
     type: "github_org"
 ```
 
@@ -72,6 +73,7 @@ Any plugins defined in `lib/entitlements-and-plugins` will be loaded and used at
     dir: github.com/github/teams
     org: github
     token: <%= ENV["GITHUB_ORG_TOKEN"] %>
+    ignore_not_found: false # optional argument to ignore users who are not found in the GitHub instance
     type: "github_team"
 ```
 

--- a/lib/entitlements/backend/github_org/controller.rb
+++ b/lib/entitlements/backend/github_org/controller.rb
@@ -120,12 +120,13 @@ module Entitlements
         Contract String, C::HashOf[String => C::Any] => nil
         def validate_config!(key, data)
           spec = COMMON_GROUP_CONFIG.merge({
-            "base"     => { required: true, type: String },
-            "addr"     => { required: false, type: String },
-            "org"      => { required: true, type: String },
-            "token"    => { required: true, type: String },
-            "features" => { required: false, type: Array },
-            "ignore"   => { required: false, type: Array }
+            "base"             => { required: true, type: String },
+            "addr"             => { required: false, type: String },
+            "org"              => { required: true, type: String },
+            "token"            => { required: true, type: String },
+            "features"         => { required: false, type: Array },
+            "ignore"           => { required: false, type: Array },
+            "ignore_not_found" => { required: false, type: [FalseClass, TrueClass] },
           })
           text = "GitHub organization group #{key.inspect}"
           Entitlements::Util::Util.validate_attr!(spec, data, text)

--- a/lib/entitlements/backend/github_org/provider.rb
+++ b/lib/entitlements/backend/github_org/provider.rb
@@ -25,7 +25,8 @@ module Entitlements
             org: config.fetch("org"),
             addr: config.fetch("addr", nil),
             token: config.fetch("token"),
-            ou: config.fetch("base")
+            ou: config.fetch("base"),
+            ignore_not_found: config.fetch("ignore_not_found", false)
           )
           @role_cache = {}
         end

--- a/lib/entitlements/backend/github_team/controller.rb
+++ b/lib/entitlements/backend/github_team/controller.rb
@@ -110,7 +110,8 @@ module Entitlements
             "base"  => { required: true, type: String },
             "addr"  => { required: false, type: String },
             "org"   => { required: true, type: String },
-            "token" => { required: true, type: String }
+            "token" => { required: true, type: String },
+            "ignore_not_found" => { required: false, type: [FalseClass, TrueClass] },
           })
           text = "GitHub group #{key.inspect}"
           Entitlements::Util::Util.validate_attr!(spec, data, text)

--- a/lib/entitlements/backend/github_team/provider.rb
+++ b/lib/entitlements/backend/github_team/provider.rb
@@ -23,7 +23,8 @@ module Entitlements
             org: config.fetch("org"),
             addr: config.fetch("addr", nil),
             token: config.fetch("token"),
-            ou: config.fetch("base")
+            ou: config.fetch("base"),
+            ignore_not_found: config.fetch("ignore_not_found", false)
           )
 
           @github_team_cache = {}

--- a/lib/entitlements/backend/github_team/service.rb
+++ b/lib/entitlements/backend/github_team/service.rb
@@ -437,8 +437,16 @@ module Entitlements
           end
           Entitlements.logger.debug "#{identifier} add_user_to_team(user=#{user}, org=#{org}, team_id=#{team.team_id}, role=#{role})"
           validate_team_id_and_slug!(team.team_id, team.team_name)
-          result = octokit.add_team_membership(team.team_id, user, role:)
-          result[:state] == "active" || result[:state] == "pending"
+
+          begin
+            result = octokit.add_team_membership(team.team_id, user, role:)
+            result[:state] == "active" || result[:state] == "pending"
+          rescue Octokit::NotFound => e
+            raise e unless ignore_not_found
+
+            Entitlements.logger.warn "User #{user} not found in GitHub instance #{identifier}, ignoring."
+            false
+          end
         end
 
         # Remove user from team.

--- a/lib/entitlements/backend/github_team/service.rb
+++ b/lib/entitlements/backend/github_team/service.rb
@@ -28,9 +28,10 @@ module Entitlements
           addr: C::Maybe[String],
           org: String,
           token: String,
-          ou: String
+          ou: String,
+          ignore_not_found: C::Bool,
         ] => C::Any
-        def initialize(addr: nil, org:, token:, ou:)
+        def initialize(addr: nil, org:, token:, ou:, ignore_not_found: false)
           super
           Entitlements.cache[:github_team_members] ||= {}
           Entitlements.cache[:github_team_members][org] ||= {}

--- a/lib/entitlements/service/github.rb
+++ b/lib/entitlements/service/github.rb
@@ -17,7 +17,7 @@ module Entitlements
       MAX_GRAPHQL_RETRIES = 3
       WAIT_BETWEEN_GRAPHQL_RETRIES = 1
 
-      attr_reader :addr, :org, :token, :ou
+      attr_reader :addr, :org, :token, :ou, :ignore_not_found
 
       # Constructor.
       #
@@ -31,14 +31,16 @@ module Entitlements
         addr: C::Maybe[String],
         org: String,
         token: String,
-        ou: String
+        ou: String,
+        ignore_not_found: C::Bool,
       ] => C::Any
-      def initialize(addr: nil, org:, token:, ou:)
+      def initialize(addr: nil, org:, token:, ou:, ignore_not_found: false)
         # Save some parameters for the connection but don't actually connect yet.
         @addr = addr
         @org = org
         @token = token
         @ou = ou
+        @ignore_not_found = ignore_not_found
 
         # This is a global cache across all invocations of this object. GitHub membership
         # need to be obtained only one time per organization, but might be used multiple times.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Entitlements
   module Version
-    VERSION = "0.4.4"
+    VERSION = "0.5.0"
   end
 end

--- a/spec/unit/entitlements/backend/github_org/controller_spec.rb
+++ b/spec/unit/entitlements/backend/github_org/controller_spec.rb
@@ -9,10 +9,11 @@ describe Entitlements::Backend::GitHubOrg::Controller do
   let(:backend_config) { base_backend_config }
   let(:base_backend_config) do
     {
-      "org"   => "kittensinc",
-      "token" => "CuteAndCuddlyKittens",
-      "type"  => "github_org",
-      "base"  => "ou=kittensinc,ou=GitHub,dc=github,dc=com"
+      "org"              => "kittensinc",
+      "token"            => "CuteAndCuddlyKittens",
+      "type"             => "github_org",
+      "base"             => "ou=kittensinc,ou=GitHub,dc=github,dc=com",
+      "ignore_not_found" => false
     }
   end
   let(:group_name) { "foo-githuborg" }
@@ -98,9 +99,10 @@ describe Entitlements::Backend::GitHubOrg::Controller do
       it "logs expected output and returns expected actions" do
         allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
           .with("foo-githuborg", {
-            "base"  => "ou=kittensinc,ou=GitHub,dc=github,dc=com",
-            "org"   => "kittensinc",
-            "token" => "CuteAndCuddlyKittens"
+            "base"             => "ou=kittensinc,ou=GitHub,dc=github,dc=com",
+            "org"              => "kittensinc",
+            "token"            => "CuteAndCuddlyKittens",
+            "ignore_not_found" => false
           }).and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -179,7 +181,8 @@ describe Entitlements::Backend::GitHubOrg::Controller do
       end
 
       it "logs expected output and returns expected actions" do
-        allow(Entitlements::Data::Groups::Calculated).to receive(:read_all).with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+        allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
+          .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
           .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -263,7 +266,8 @@ describe Entitlements::Backend::GitHubOrg::Controller do
       end
 
       it "logs expected output and returns expected actions" do
-        allow(Entitlements::Data::Groups::Calculated).to receive(:read_all).with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+        allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
+          .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
           .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -328,7 +332,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
       it "does not run actions" do
         allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-          .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+          .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
           .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -374,7 +378,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
         it "handles removals and role changes but does not invite" do
           allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>%w[remove], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>%w[remove], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
             .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -437,7 +441,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
         it "reports as a no-op" do
           allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>%w[remove], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>%w[remove], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
             .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -486,7 +490,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
         it "handles removals and role changes but does not invite" do
           allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>%w[invite], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>%w[invite], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
             .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -555,7 +559,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
         it "reports as a no-op" do
           allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>%w[invite], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>%w[invite], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
             .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -591,9 +595,8 @@ describe Entitlements::Backend::GitHubOrg::Controller do
         cache[:predictive_state] = { by_dn: { org1_admin_dn => { members: admins, metadata: nil }, org1_member_dn => { members:, metadata: nil } }, invalid: Set.new }
 
         allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-          .with("foo-githuborg", {
-            "base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"
-          }).and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
+          .with("foo-githuborg", { "base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
+          .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
 
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -663,7 +666,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
         it "handles removals and role changes but does not invite" do
           allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>[], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>[], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
             .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -726,7 +729,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
         it "reports as a no-op" do
           allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>[], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+            .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "features"=>[], "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
             .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_admin_dn).and_return(org1_admin_group)
           allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(org1_member_dn).and_return(org1_member_group)
@@ -837,7 +840,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
   describe "#validate_github_org_ous!" do
     it "raises if an admin or member group is missing" do
       allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-        .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+        .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
         .and_return(Set.new(%w[member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
 
       github_double = instance_double(Entitlements::Backend::GitHubOrg::Provider)
@@ -857,7 +860,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
       dns = %w[admin member kittens cats].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }
 
       allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-        .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+        .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
         .and_return(Set.new(dns))
 
       allow(Entitlements::Backend::GitHubOrg::Service).to receive(:new).and_return(service)
@@ -897,11 +900,8 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
     it "raises due to duplicate users" do
       allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-        .with("foo-githuborg", {
-          "base"  => "ou=kittensinc,ou=GitHub,dc=github,dc=com",
-          "org"   => "kittensinc",
-          "token" => "CuteAndCuddlyKittens"
-        }).and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
+        .with("foo-githuborg", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
+        .and_return(Set.new(%w[admin member].map { |cn| "cn=#{cn},ou=kittensinc,ou=GitHub,dc=github,dc=com" }))
       allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(admin_dn).and_return(admin_group)
       allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(member_dn).and_return(member_group)
       allow(Entitlements::Data::Groups::Calculated).to receive(:read).with(member_dn).and_return(member_group)

--- a/spec/unit/entitlements/backend/github_org/provider_spec.rb
+++ b/spec/unit/entitlements/backend/github_org/provider_spec.rb
@@ -7,7 +7,8 @@ describe Entitlements::Backend::GitHubOrg::Provider do
       addr: "https://github.fake/api/v3",
       org: "kittensinc",
       token: "GoPackGo",
-      ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake"
+      ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake",
+      ignore_not_found: false
     }
   end
 

--- a/spec/unit/entitlements/backend/github_org/service_spec.rb
+++ b/spec/unit/entitlements/backend/github_org/service_spec.rb
@@ -185,7 +185,7 @@ describe Entitlements::Backend::GitHubOrg::Service do
           expect(logger).to receive(:debug).with("github.fake add_user_to_organization(user=bob, org=kittensinc, role=admin)")
           expect(logger).to receive(:debug).with("Setting up GitHub API connection to https://github.fake/api/v3/")
           expect(logger).to receive(:warn).with("User bob not found in GitHub instance github.fake, ignoring.")
-  
+
           stub_request(:put, "https://github.fake/api/v3/orgs/kittensinc/memberships/bob").to_return(
             status: 404,
             headers: {
@@ -196,7 +196,7 @@ describe Entitlements::Backend::GitHubOrg::Service do
               "documentation_url" => "https://docs.github.com/rest"
             })
           )
-  
+
           result = subject.send(:add_user_to_organization, "bob", "admin")
           expect(result).to eq(false)
         end

--- a/spec/unit/entitlements/backend/github_team/controller_spec.rb
+++ b/spec/unit/entitlements/backend/github_team/controller_spec.rb
@@ -11,7 +11,8 @@ describe Entitlements::Backend::GitHubTeam::Controller do
       "org"   => "kittensinc",
       "token" => "CuteAndCuddlyKittens",
       "type"  => "github_team",
-      "base"  => "ou=kittensinc,ou=GitHub,dc=github,dc=com"
+      "base"  => "ou=kittensinc,ou=GitHub,dc=github,dc=com",
+      "ignore_not_found" => false
     }
   end
   let(:group_name) { "foo-githubteam" }
@@ -110,7 +111,7 @@ describe Entitlements::Backend::GitHubTeam::Controller do
 
      it "logs expected output and returns expected actions" do
         allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-          .with("foo-githubteam", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+          .with("foo-githubteam", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
           .and_return(Set.new(%w[snowshoes russian-blues]))
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with("snowshoes").and_return(snowshoe_group)
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with("russian-blues").and_return(russian_blue_group)
@@ -158,7 +159,7 @@ describe Entitlements::Backend::GitHubTeam::Controller do
 
       it "does not run actions if there are no diffs detected" do
         allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-          .with("foo-githubteam", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+          .with("foo-githubteam", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
           .and_return(Set.new(%w[russian-blues]))
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with("russian-blues").and_return(russian_blue_group)
         allow(Entitlements::Util::Util).to receive(:dns_for_ou).with("foo-githubteam", anything).and_return([russian_blue_group.dn])
@@ -204,7 +205,7 @@ describe Entitlements::Backend::GitHubTeam::Controller do
 
       it "logs expected output and returns expected actions" do
         allow(Entitlements::Data::Groups::Calculated).to receive(:read_all)
-          .with("foo-githubteam", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens"})
+          .with("foo-githubteam", {"base"=>"ou=kittensinc,ou=GitHub,dc=github,dc=com", "org"=>"kittensinc", "token"=>"CuteAndCuddlyKittens", "ignore_not_found"=>false})
           .and_return(Set.new(%w[snowshoes russian-blues]))
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with("snowshoes").and_return(snowshoe_group)
         allow(Entitlements::Data::Groups::Calculated).to receive(:read).with("russian-blues").and_return(russian_blue_group)

--- a/spec/unit/entitlements/backend/github_team/provider_spec.rb
+++ b/spec/unit/entitlements/backend/github_team/provider_spec.rb
@@ -7,7 +7,8 @@ describe Entitlements::Backend::GitHubTeam::Provider do
       addr: "https://github.fake/api/v3",
       org: "kittensinc",
       token: "GoPackGo",
-      ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake"
+      ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake",
+      ignore_not_found: false
     }
   end
 

--- a/spec/unit/entitlements/backend/github_team/service_spec.rb
+++ b/spec/unit/entitlements/backend/github_team/service_spec.rb
@@ -585,13 +585,13 @@ describe Entitlements::Backend::GitHubTeam::Service do
       it "raises when user is not found" do
         expect(subject).to receive(:validate_team_id_and_slug!).with(1001, "russian-blues").and_return(true)
         expect(subject).to receive(:org_members).and_return(Set.new(%w[blackmanx]))
-  
+
         add_membership_response = {
           "url"   => "https://github.fake/api/v3/teams/1001/memberships/blackmanx",
           "role"  => "member",
           "state" => "active"
         }
-  
+
         stub_request(:put, "https://github.fake/api/v3/teams/1001/memberships/blackmanx")
           .to_return(
             status: 404,
@@ -622,13 +622,13 @@ describe Entitlements::Backend::GitHubTeam::Service do
       it "ignores 404s" do
         expect(subject).to receive(:validate_team_id_and_slug!).with(1001, "russian-blues").and_return(true)
         expect(subject).to receive(:org_members).and_return(Set.new(%w[blackmanx]))
-  
+
         add_membership_response = {
           "url"   => "https://github.fake/api/v3/teams/1001/memberships/blackmanx",
           "role"  => "member",
           "state" => "active"
         }
-  
+
         stub_request(:put, "https://github.fake/api/v3/teams/1001/memberships/blackmanx")
           .to_return(
             status: 404,

--- a/spec/unit/entitlements/backend/github_team/service_spec.rb
+++ b/spec/unit/entitlements/backend/github_team/service_spec.rb
@@ -580,6 +580,71 @@ describe Entitlements::Backend::GitHubTeam::Service do
       result = subject.send(:add_user_to_team, user: "blackmanx", team:)
       expect(result).to eq(false)
     end
+
+    context "ignore_not_found is false" do
+      it "raises when user is not found" do
+        expect(subject).to receive(:validate_team_id_and_slug!).with(1001, "russian-blues").and_return(true)
+        expect(subject).to receive(:org_members).and_return(Set.new(%w[blackmanx]))
+  
+        add_membership_response = {
+          "url"   => "https://github.fake/api/v3/teams/1001/memberships/blackmanx",
+          "role"  => "member",
+          "state" => "active"
+        }
+  
+        stub_request(:put, "https://github.fake/api/v3/teams/1001/memberships/blackmanx")
+          .to_return(
+            status: 404,
+            headers: {
+              "Content-Type" => "application/json"
+            },
+            body: JSON.generate({
+              "message"           => "Not Found",
+              "documentation_url" => "https://docs.github.com/rest"
+            })
+          )
+
+        expect { subject.send(:add_user_to_team, user: "blackmanx", team:) }.to raise_error(Octokit::NotFound)
+      end
+    end
+
+    context "ignore_not_found is true" do
+      let(:subject) do
+        described_class.new(
+          addr: "https://github.fake/api/v3",
+          org: "kittensinc",
+          token: "GoPackGo",
+          ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake",
+          ignore_not_found: true
+        )
+      end
+
+      it "ignores 404s" do
+        expect(subject).to receive(:validate_team_id_and_slug!).with(1001, "russian-blues").and_return(true)
+        expect(subject).to receive(:org_members).and_return(Set.new(%w[blackmanx]))
+  
+        add_membership_response = {
+          "url"   => "https://github.fake/api/v3/teams/1001/memberships/blackmanx",
+          "role"  => "member",
+          "state" => "active"
+        }
+  
+        stub_request(:put, "https://github.fake/api/v3/teams/1001/memberships/blackmanx")
+          .to_return(
+            status: 404,
+            headers: {
+              "Content-type" => "application/json"
+            },
+            body: JSON.generate({
+              "message"           => "Not Found",
+              "documentation_url" => "https://docs.github.com/rest"
+            })
+          )
+
+        result = subject.send(:add_user_to_team, user: "blackmanx", team:)
+        expect(result).to eq(false)
+      end
+    end
   end
 
   describe "#remove_user_from_team" do

--- a/spec/unit/entitlements/backend/github_team/service_spec.rb
+++ b/spec/unit/entitlements/backend/github_team/service_spec.rb
@@ -11,7 +11,8 @@ describe Entitlements::Backend::GitHubTeam::Service do
       addr: "https://github.fake/api/v3",
       org: "kittensinc",
       token: "GoPackGo",
-      ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake"
+      ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake",
+      ignore_not_found: false
     )
   end
 

--- a/spec/unit/entitlements/service/github_spec.rb
+++ b/spec/unit/entitlements/service/github_spec.rb
@@ -8,7 +8,8 @@ describe Entitlements::Service::GitHub do
       addr: "https://github.fake/api/v3",
       org: "kittensinc",
       token: "GoPackGo",
-      ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake"
+      ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake",
+      ignore_not_found: false
     )
   end
 
@@ -17,7 +18,8 @@ describe Entitlements::Service::GitHub do
       subject = described_class.new(
         org: "kittensinc",
         token: "GoPackGo",
-        ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake"
+        ou: "ou=kittensinc,ou=GitHub,dc=github,dc=fake",
+        ignore_not_found: false
       )
       expect(subject.identifier).to eq("github.com")
     end


### PR DESCRIPTION
This PR introduces a new configuration option, `ignore_not_found`, which allows entitlements to ignore `HTTP 404` errors when trying to perform organization and team membership operations on a GitHub instance where the user doesn't exist.

Sometimes this option may be desirable when GitHub instance users are ultimately provisioned by other entitlements plugins and there is a race condition where this plugin may try to add a member before they exist.

For example, users may be provisioned in a GitHub instance via Enterprise Managed Users backed by an IdP which is also fed by entitlements. If the SCIM requests don't complete before this plugin is executed, the member will not exist in the instance and the run will fail.  Since entitlements is designed to be run often, it may be acceptable to allow an "eventually consistent" state where entitlements would add the user the next time it runs once it's provisioned by the IdP.