### PR TITLE
Bug: Support cases where `ignore_not_found` is not provided

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entitlements-github-plugin (0.5.0)
+    entitlements-github-plugin (0.5.1)
       contracts (~> 0.17.0)
       faraday (~> 2.0)
       faraday-retry (~> 2.0)

--- a/lib/entitlements/backend/github_team/service.rb
+++ b/lib/entitlements/backend/github_team/service.rb
@@ -18,10 +18,11 @@ module Entitlements
 
         # Constructor.
         #
-        # addr   - Base URL a GitHub Enterprise API (leave undefined to use dotcom)
-        # org    - String with organization name
-        # token  - Access token for GitHub API
-        # ou     - Base OU for fudged DNs
+        # addr             - Base URL a GitHub Enterprise API (leave undefined to use dotcom)
+        # org              - String with organization name
+        # token            - Access token for GitHub API
+        # ou               - Base OU for fudged DNs
+        # ignore_not_found - Boolean to ignore not found errors
         #
         # Returns nothing.
         Contract C::KeywordArgs[
@@ -29,7 +30,7 @@ module Entitlements
           org: String,
           token: String,
           ou: String,
-          ignore_not_found: C::Bool,
+          ignore_not_found: C::Maybe[C::Bool],
         ] => C::Any
         def initialize(addr: nil, org:, token:, ou:, ignore_not_found: false)
           super

--- a/lib/entitlements/service/github.rb
+++ b/lib/entitlements/service/github.rb
@@ -21,10 +21,11 @@ module Entitlements
 
       # Constructor.
       #
-      # addr   - Base URL a GitHub Enterprise API (leave undefined to use dotcom)
-      # org    - String with organization name
-      # token  - Access token for GitHub API
-      # ou     - Base OU for fudged DNs
+      # addr             - Base URL a GitHub Enterprise API (leave undefined to use dotcom)
+      # org              - String with organization name
+      # token            - Access token for GitHub API
+      # ou               - Base OU for fudged DNs
+      # ignore_not_found - Boolean to ignore not found errors
       #
       # Returns nothing.
       Contract C::KeywordArgs[
@@ -32,7 +33,7 @@ module Entitlements
         org: String,
         token: String,
         ou: String,
-        ignore_not_found: C::Bool,
+        ignore_not_found: C::Maybe[C::Bool],
       ] => C::Any
       def initialize(addr: nil, org:, token:, ou:, ignore_not_found: false)
         # Save some parameters for the connection but don't actually connect yet.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Entitlements
   module Version
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end


### PR DESCRIPTION
This pull request fixes a bug where `entitlements` would throw an exception and crash if `ignore_not_found` is not provided via a configuration. This is an issue with the way Ruby's `Contracts` Gem handles optional input params. If the `ignore_not_found` value is not provided, it will default to `false` but the way `Contracts` is setup it expects the input option to be a Boolean. This pull request fixes that with the `Maybe` keyword.

related: https://github.com/github/entitlements-github-plugin/pull/28