### PR TITLE
Fix the entitlements team cache when there are multiple instances of GitHub in use.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entitlements-github-plugin (0.5.2)
+    entitlements-github-plugin (0.5.3)
       contracts (~> 0.17.0)
       faraday (~> 2.0)
       faraday-retry (~> 2.0)

--- a/lib/entitlements/backend/github_team/service.rb
+++ b/lib/entitlements/backend/github_team/service.rb
@@ -35,9 +35,8 @@ module Entitlements
         def initialize(addr: nil, org:, token:, ou:, ignore_not_found: false)
           super
           Entitlements.cache[:github_team_members] ||= {}
-          Entitlements.cache[:github_team_members][addr] ||= {}
-          Entitlements.cache[:github_team_members][addr][org] ||= {}
-          @team_cache = Entitlements.cache[:github_team_members][addr][org]
+          Entitlements.cache[:github_team_members][org_signature] ||= {}
+          @team_cache = Entitlements.cache[:github_team_members][org_signature]
         end
 
         # Read a single team identified by its slug and return a team object.

--- a/lib/entitlements/backend/github_team/service.rb
+++ b/lib/entitlements/backend/github_team/service.rb
@@ -35,8 +35,9 @@ module Entitlements
         def initialize(addr: nil, org:, token:, ou:, ignore_not_found: false)
           super
           Entitlements.cache[:github_team_members] ||= {}
-          Entitlements.cache[:github_team_members][org] ||= {}
-          @team_cache = Entitlements.cache[:github_team_members][org]
+          Entitlements.cache[:github_team_members][addr] ||= {}
+          Entitlements.cache[:github_team_members][addr][org] ||= {}
+          @team_cache = Entitlements.cache[:github_team_members][addr][org]
         end
 
         # Read a single team identified by its slug and return a team object.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Entitlements
   module Version
-    VERSION = "0.5.2"
+    VERSION = "0.5.3"
   end
 end


### PR DESCRIPTION
I think currently the team cache gets confused when you have multiple GitHub Enterprise Server instances (or one Enterprise instance and DotCom) that have an organization and team with the same name.

To avoid this, I believe we need to include the base address of the instance as part of the cache structure. This ensures each instance has its own cache.