### PR TITLE
Pin rack version for acceptance test mock servers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entitlements-github-plugin (0.5.1)
+    entitlements-github-plugin (0.5.2)
       contracts (~> 0.17.0)
       faraday (~> 2.0)
       faraday-retry (~> 2.0)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Entitlements
   module Version
-    VERSION = "0.5.1"
+    VERSION = "0.5.2"
   end
 end

--- a/spec/acceptance/github-server/Gemfile
+++ b/spec/acceptance/github-server/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "rack"
+gem "rack", "~>2.2.8"
 gem "rack-test"
-gem "sinatra"
+gem "sinatra", "~>3.2.0"
 gem "webrick"


### PR DESCRIPTION
This PR pins the versions for rack and sinatra in the acceptance test mock servers to avoid breaking changes in the new major versions. These mock servers are not used outside of tests.