### PR TITLE
Ignore adding team members that are not in the organization.

### DIFF
--- a/lib/entitlements/backend/github_team/service.rb
+++ b/lib/entitlements/backend/github_team/service.rb
@@ -459,6 +459,11 @@ module Entitlements
           begin
             result = octokit.add_team_membership(team.team_id, user, role:)
             result[:state] == "active" || result[:state] == "pending"
+          rescue Octokit::UnprocessableEntity => e
+            raise e unless ignore_not_found && e.message =~ /Enterprise Managed Users must be part of the organization to be assigned to the team/
+
+            Entitlements.logger.warn "User #{user} not found in GitHub instance #{identifier}, ignoring."
+            false
           rescue Octokit::NotFound => e
             raise e unless ignore_not_found
 


### PR DESCRIPTION
This PR updates the logic for adding users to an organization team to ignore adding said user if they are non a member of the organization.