### PR TITLE
Add security-manager to github_org.rb

### DIFF
--- a/lib/entitlements/backend/github_org.rb
+++ b/lib/entitlements/backend/github_org.rb
@@ -12,7 +12,8 @@ module Entitlements
       ORGANIZATION_ROLES = {
         "admin"  => "ADMIN",
         # `billing-manager` is currently not supported
-        "member" => "MEMBER"
+        "member" => "MEMBER",
+        "security-manager" => "SECURITY-MANAGER"
       }
 
       # Error classes

--- a/lib/entitlements/backend/github_org.rb
+++ b/lib/entitlements/backend/github_org.rb
@@ -13,7 +13,7 @@ module Entitlements
         "admin"  => "ADMIN",
         # `billing-manager` is currently not supported
         "member" => "MEMBER",
-        "security-manager" => "SECURITY-MANAGER"
+        "security_manager" => "SECURITY-MANAGER"
       }
 
       # Error classes

--- a/lib/entitlements/backend/github_org/provider.rb
+++ b/lib/entitlements/backend/github_org/provider.rb
@@ -104,7 +104,15 @@ module Entitlements
         # Returns an Entitlements::Models::Group object.
         Contract String => Entitlements::Models::Group
         def role_to_group(role)
-          members = github.org_members.keys.select { |username| github.org_members[username] == role }
+          # The security_manager role is a special case because it is not a role that is
+          # part of the org membership API. Instead, it is a role that is assigned to users via
+          # the org role API.
+          if role == "security_manager"
+            members = github.users_with_role(role)
+          else
+            members = github.org_members.keys.select { |username| github.org_members[username] == role }
+          end
+
           Entitlements::Models::Group.new(
             dn: role_dn(role),
             members: Set.new(members),


### PR DESCRIPTION
This pull request includes an update to the `GitHubOrg` class in the `lib/entitlements/backend/github_org.rb` file to support a new role. The most important change is the addition of the "security-manager" role to the `ORGANIZATION_ROLES` hash.

* [`lib/entitlements/backend/github_org.rb`](diffhunk://#diff-671a2cb4326373a37bf9f97ff6fe7312ce6f7eade1f43977632285498970336aL15-R16): Added "security-manager" role to the `ORGANIZATION_ROLES` hash.

/cc https://github.com/github/entitlements/pull/101743#issuecomment-2656664339
/cc https://github.com/github/security-services/issues/190