### PR TITLE
fix(github_team): rescue all UnprocessableEntity

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entitlements-github-plugin (1.2.2)
+    entitlements-github-plugin (1.2.3)
       contracts (~> 0.17.0)
       faraday (~> 2.0)
       faraday-retry (~> 2.0)
@@ -180,4 +180,4 @@ DEPENDENCIES
   webmock (~> 3.23, >= 3.23.1)
 
 BUNDLED WITH
-   2.5.9
+   2.7.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,4 +180,4 @@ DEPENDENCIES
   webmock (~> 3.23, >= 3.23.1)
 
 BUNDLED WITH
-   2.7.2
+   2.5.9

--- a/lib/entitlements/backend/github_team/service.rb
+++ b/lib/entitlements/backend/github_team/service.rb
@@ -477,8 +477,6 @@ module Entitlements
 
             result[:state] == "active" || result[:state] == "pending"
           rescue Octokit::UnprocessableEntity => e
-            raise e unless ignore_not_found && e.message =~ /Enterprise Managed Users must be part of the organization to be assigned to the team/
-
             Entitlements.logger.warn "User #{user} not found in organization #{org}, ignoring."
             false
           rescue Octokit::NotFound => e

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Entitlements
   module Version
-    VERSION = "1.2.2"
+    VERSION = "1.2.3"
   end
 end


### PR DESCRIPTION
For all intent and purposes, every cases of UnprocessableEntity should be rescued, as they might all lead to the same underlying issue of a user blocking the invites.

This means that the full reconciliation will have to happen out of bounds, but at least the deployment will not fail.

cc https://github.com/github/entitlements-github-plugin/pull/288/changes