### PR TITLE
Prefetch organization pending members

### DIFF
--- a/lib/entitlements/backend/github_org/controller.rb
+++ b/lib/entitlements/backend/github_org/controller.rb
@@ -140,8 +140,14 @@ module Entitlements
           end
         end
 
+        # Pre-fetch the current state of the organization from the API. Both of these are memoized
+        # by the provider, so calling them here means `calculate` reuses the result instead of
+        # making the request itself. Entitlements runs `prefetch` for every group through a thread
+        # pool sized by `max_parallelism`, whereas `calculate` runs serially, so fetching here lets
+        # these requests overlap across organizations.
         def prefetch
           existing_groups
+          provider.pending_members
         end
 
         private

--- a/spec/unit/entitlements/backend/github_org/controller_spec.rb
+++ b/spec/unit/entitlements/backend/github_org/controller_spec.rb
@@ -603,7 +603,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
         service = subject.send(:provider).github
         expect(service).to receive(:members_and_roles_from_rest).and_return(answer2)
-        expect(service).to receive(:pending_members).exactly(2).times.and_return(Set.new)
+        expect(service).to receive(:pending_members).exactly(3).times.and_return(Set.new)
 
         expect(logger).to receive(:debug).with("Loading organization members and roles for kittensinc from cache")
         expect(logger).to receive(:debug).with("Currently kittensinc has 1 admin(s) and 2 member(s)")
@@ -845,6 +845,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
       github_double = instance_double(Entitlements::Backend::GitHubOrg::Provider)
       allow(subject).to receive(:provider).and_return(github_double)
+      allow(github_double).to receive(:pending_members).and_return(Set.new)
       allow(github_double).to receive(:read).with("cn=member,ou=kittensinc,ou=GitHub,dc=github,dc=com").and_return({})
       allow(github_double).to receive(:read).with("cn=admin,ou=kittensinc,ou=GitHub,dc=github,dc=com").and_return({})
 
@@ -868,6 +869,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
       github_double = instance_double(Entitlements::Backend::GitHubOrg::Provider)
       allow(subject).to receive(:provider).and_return(github_double)
+      allow(github_double).to receive(:pending_members).and_return(Set.new)
       dns.each do |dn|
         allow(github_double).to receive(:read).with(dn).and_return({})
       end
@@ -911,6 +913,7 @@ describe Entitlements::Backend::GitHubOrg::Controller do
 
       github_double = instance_double(Entitlements::Backend::GitHubOrg::Provider)
       allow(subject).to receive(:provider).and_return(github_double)
+      allow(github_double).to receive(:pending_members).and_return(Set.new)
       allow(github_double).to receive(:read).with(admin_dn).and_return(admin_group)
       allow(github_double).to receive(:read).with(member_dn).and_return(member_group)
 


### PR DESCRIPTION
## What this does

Moves the organization pending member lookup into `prefetch`, which entitlements runs through a thread pool, instead of leaving it in `calculate`, which runs serially.

On a no-op deploy across a large set of organizations, that one call accounts for roughly half of the entire run.

| Phase | Time | Runs concurrently |
| --- | --- | --- |
| `calculate` | 526s | no |
| of which pending member lookups | 341s | no |
| `prefetch` and `validate` | 148s | yes, sized by `max_parallelism` |

The lookups are not redundant, so caching does not help. Each one is a different organization returning a different result, and every second of that 341s is time spent waiting on the API. The only way to shorten it is to let the requests overlap, and `prefetch` is already the phase built to do that.

## How

**`GitHubOrg::Controller#prefetch` now calls `provider.pending_members` alongside `existing_groups`.** The result is memoized in `Entitlements.cache[:github_pending_members]`, so `changes` reuses it later in `calculate` rather than issuing the request itself. The number of API requests is unchanged. Only the phase they happen in moves.

**Three controller specs gained a `pending_members` stub** on their provider `instance_double`, since those examples call `prefetch` directly. One strict call count went from two to three, because that example stubs the service rather than the provider and so bypasses the memoization that keeps the real request count flat.

`GitHubTeam::Controller` is left alone. Its `prefetch` already warms the provider reads that its `calculate` consumes.

## Notes

This pays off only when `max_parallelism` is greater than 1. At the default of 1 the `prefetch` pool is serial as well, so the work still moves out of `calculate` but the wall time stays the same. Nothing regresses in that case, which makes this safe to land ahead of any consumer raising the value.

Full suite passes with 100 percent coverage and RuboCop is clean.
