### PR TITLE
Cache the GHES instance check across organizations

### DIFF
--- a/lib/entitlements/service/github.rb
+++ b/lib/entitlements/service/github.rb
@@ -52,6 +52,7 @@ module Entitlements
         # need to be obtained only one time per organization, but might be used multiple times.
         Entitlements.cache[:github_pending_members] ||= {}
         Entitlements.cache[:github_org_members] ||= {}
+        Entitlements.cache[:github_enterprise] ||= {}
       end
 
       # Return the identifier, either the address specified or otherwise "github.com".
@@ -97,13 +98,23 @@ module Entitlements
       end
 
       # Returns true if the github instance is an enterprise server instance
+      #
+      # Whether an instance is GHES is a property of the instance and not of any one organization,
+      # so this is cached against the address rather than the org signature. Without this the meta
+      # endpoint is queried once per organization, which is a request per org for an answer that
+      # cannot vary between them. Note this caches false as well as true, so it checks for the key
+      # rather than using ||=, since github.com correctly answers false here.
       Contract C::None => C::Bool
       def enterprise?
+        instance_signature = addr || ""
+        cache = Entitlements.cache[:github_enterprise]
+        return cache[instance_signature] if cache.key?(instance_signature)
+
         meta = Retryable.with_context(:default) do
           octokit.github_meta
         end
 
-        meta.key? :installed_version
+        cache[instance_signature] = meta.key?(:installed_version)
       end
 
       # Read the members of an organization who are in a "pending" role. These users should

--- a/spec/unit/entitlements/service/github_spec.rb
+++ b/spec/unit/entitlements/service/github_spec.rb
@@ -70,6 +70,28 @@ describe Entitlements::Service::GitHub do
                   })
       expect(subject.enterprise?).to eq(true)
     end
+
+    it "queries the API only once per instance across multiple organizations" do
+      stub = stub_request(:get, "https://github.fake/api/v3/meta").
+        to_return({
+                    body: JSON.dump({ verifiable_password_authentication: true }),
+                    headers: {
+                      content_type: "application/json; charset=utf-8"
+                    }
+                  })
+
+      other_org = described_class.new(
+        addr: "https://github.fake/api/v3",
+        org: "puppiesinc",
+        token: "GoPackGo",
+        ou: "ou=puppiesinc,ou=GitHub,dc=github,dc=fake",
+        ignore_not_found: false
+      )
+
+      expect(subject.enterprise?).to eq(false)
+      expect(other_org.enterprise?).to eq(false)
+      expect(stub).to have_been_requested.once
+    end
   end
 
   describe "#pending_members" do


### PR DESCRIPTION
## What this does

Caches the GHES instance check so it costs one API request per instance instead of one per organization.

`pending_members` calls `enterprise?` before it does anything else, and `enterprise?` queried the meta endpoint every single time with no caching. Since `pending_members` is memoized per organization, that worked out to one meta request per org, for an answer that cannot vary between orgs on the same instance.

Measured on a run covering 165 organizations, the pending member lookups cost 362s in total. Regressing that against the number of pending members in each org splits it into a fixed cost and a pagination cost.

| Component | Time |
| --- | --- |
| Fixed, 0.82s per org | 136s |
| Pagination, 23ms per pending member | 226s |

The 124 orgs that have no pending members at all still cost 0.86s each, and in that case the work is exactly two API requests, the meta check and one empty page. So the meta check is roughly half the fixed cost, and removing it should save somewhere around 70s on a run of that size. That last step assumes the two requests have similar latency, so treat it as an estimate rather than a measurement.

## How

**`enterprise?` now caches against the address rather than the org signature.** GHES-ness is a property of the instance, so the address is the correct key. `org_signature` would keep the request count at one per org and defeat the point.

**The cache is read with `key?` rather than `||=`.** `false` is a valid answer here and the one github.com gives, so `||=` would treat every cached result as a miss and change nothing.

**One spec covers it**, asserting the meta endpoint is requested once across two service objects for different orgs on the same instance. Without the change it is requested twice.

## Notes

This is independent of #297 and the two can land in either order. This one stands alone and does not depend on `max_parallelism`.

Full suite passes with 100 percent coverage and RuboCop is clean.
